### PR TITLE
Rename gem to cassava_rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An unopinionated Cassandra client built on top of the Datastax Cassandra Driver.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'cassava', github: 'backupify/cassava'
+gem 'cassava_rb', github: 'backupify/cassava'
 ```
 
 And then execute:
@@ -20,7 +20,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install cassava
+    $ gem install cassava_rb
 
 ## Usage
 

--- a/cassava_rb.gemspec
+++ b/cassava_rb.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'cassava/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "cassava"
+  spec.name          = "cassava_rb"
   spec.version       = Cassava::VERSION
   spec.authors       = ["Arron Norwell"]
   spec.email         = ["anorwell@datto.com"]


### PR DESCRIPTION
The gem 'cassava' already exists on RubyGems. This renames the gem to
'cassava_rb', without changing any module names.
