### PR TITLE
ttl support

### DIFF
--- a/lib/cassava/client.rb
+++ b/lib/cassava/client.rb
@@ -12,7 +12,7 @@ module Cassava
 
     # @see #insert
     def insert_async(table, data, ttl = nil)
-      executor.execute_async(insert_statement(table, data), :arguments => data.values)
+      executor.execute_async(insert_statement(table, data, ttl), :arguments => data.values)
     end
 
     # @param table [Symbol] the table name

--- a/lib/cassava/client.rb
+++ b/lib/cassava/client.rb
@@ -11,14 +11,14 @@ module Cassava
     end
 
     # @see #insert
-    def insert_async(table, data)
+    def insert_async(table, data, ttl = nil)
       executor.execute_async(insert_statement(table, data), :arguments => data.values)
     end
 
     # @param table [Symbol] the table name
     # @param data [Hash] A hash of column names to data, which will be inserted into the table
-    def insert(table, data)
-      statement = insert_statement(table, data)
+    def insert(table, data, ttl = nil)
+      statement = insert_statement(table, data, ttl)
       executor.execute(statement, :arguments => data.values)
     end
 
@@ -52,9 +52,10 @@ module Cassava
 
     private
 
-    def insert_statement(table, data)
+    def insert_statement(table, data, ttl = nil)
       column_names = data.keys
       statement_cql = "INSERT INTO #{table} (#{column_names.join(', ')}) VALUES (#{column_names.map { |x| '?' }.join(',')})"
+      statement_cql += " USING TTL #{ttl}" if ttl
       executor.prepare(statement_cql)
     end
   end

--- a/lib/cassava/version.rb
+++ b/lib/cassava/version.rb
@@ -1,3 +1,3 @@
 module Cassava
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/test/cassava/client_test.rb
+++ b/test/cassava/client_test.rb
@@ -47,7 +47,7 @@ module Cassava
         ttl = 12345
         @client.insert(:test, item, ttl)
 
-        assert @client.send(:insert_statement, :test, item, ttl) =~ /\sUSING\sTTL\s#{ttl}/
+        assert @client.send(:insert_statement, :test, item, ttl).cql =~ /\sUSING\sTTL\s#{ttl}$/
         assert_equal string_keys(item), @client.select(:test).execute.first
       end
     end

--- a/test/cassava/client_test.rb
+++ b/test/cassava/client_test.rb
@@ -41,6 +41,15 @@ module Cassava
         @client.insert(:test, item)
         assert_equal string_keys(item), @client.select(:test).execute.first
       end
+
+      should 'allow the insertion with a ttl' do
+        item = { :id => 'i', :a => 1, :b => 'b', :c => "'\"item(", :d => 1}
+        ttl = 12345
+        @client.insert(:test, item, ttl)
+
+        assert @client.send(:insert_statement, :test, item, ttl) =~ /\sUSING\sTTL\s#{ttl}/
+        assert_equal string_keys(item), @client.select(:test).execute.first
+      end
     end
 
     context 'select' do


### PR DESCRIPTION
allows an optional ttl argument to be passed into insert, and updates insert_statement to handle this correctly by adding USING TTL ttl_value appropriately.  Part of an effort to support ttls for storage metadata to allow cdr for docs (and later other service types) here http://jira.datto.lan/browse/BFY-2350