### PR TITLE
shifts logic to not take extra insert arg

### DIFF
--- a/lib/cassava/client.rb
+++ b/lib/cassava/client.rb
@@ -11,13 +11,15 @@ module Cassava
     end
 
     # @see #insert
-    def insert_async(table, data, ttl = nil)
+    def insert_async(table, data)
+      ttl = data.delete(:ttl)
       executor.execute_async(insert_statement(table, data, ttl), :arguments => data.values)
     end
 
     # @param table [Symbol] the table name
     # @param data [Hash] A hash of column names to data, which will be inserted into the table
-    def insert(table, data, ttl = nil)
+    def insert(table, data)
+      ttl = data.delete(:ttl)
       statement = insert_statement(table, data, ttl)
       executor.execute(statement, :arguments => data.values)
     end

--- a/lib/cassava/version.rb
+++ b/lib/cassava/version.rb
@@ -1,3 +1,3 @@
 module Cassava
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/test/cassava/client_test.rb
+++ b/test/cassava/client_test.rb
@@ -43,9 +43,9 @@ module Cassava
       end
 
       should 'allow the insertion with a ttl' do
-        item = { :id => 'i', :a => 1, :b => 'b', :c => "'\"item(", :d => 1}
         ttl = 12345
-        @client.insert(:test, item, ttl)
+        item = { :id => 'i', :a => 1, :b => 'b', :c => "'\"item(", :d => 1, :ttl => ttl }
+        @client.insert(:test, item)
 
         assert @client.send(:insert_statement, :test, item, ttl).cql =~ /\sUSING\sTTL\s#{ttl}$/
         assert_equal string_keys(item), @client.select(:test).execute.first


### PR DESCRIPTION
It occurred to me that this could and should be done without touching the Pyper code, especially since there are other things that could use Pyper's client.insert.  this way is cleaner, it pulls the ttl out of the data passed into the insert call