### PR TITLE
Prepared select ttl statement

### DIFF
--- a/lib/cassava/client.rb
+++ b/lib/cassava/client.rb
@@ -13,15 +13,25 @@ module Cassava
     # @see #insert
     def insert_async(table, data)
       ttl = data.delete(:ttl)
-      executor.execute_async(insert_statement(table, data, ttl), :arguments => data.values)
+      consistency = data.delete(:consistency)
+      if consistency.nil?
+        executor.execute_async(insert_statement(table, data, ttl), :arguments => data.values)
+      else
+        executor.execute_async(insert_statement(table, data, ttl), { :arguments => data.values, :consistency => consistency })
+      end
     end
 
     # @param table [Symbol] the table name
     # @param data [Hash] A hash of column names to data, which will be inserted into the table
     def insert(table, data)
       ttl = data.delete(:ttl)
+      consistency = data.delete(:consistency)
       statement = insert_statement(table, data, ttl)
-      executor.execute(statement, :arguments => data.values)
+      if consistency.nil?
+        executor.execute(statement, :arguments => data.values)
+      else
+        executor.execute(statement, { :arguments => data.values, :consistency => consistency })
+      end
     end
 
     # @param table [Symbol] the table name

--- a/lib/cassava/client.rb
+++ b/lib/cassava/client.rb
@@ -35,8 +35,8 @@ module Cassava
     # @param target_attr [String] The attribute to select the TTL for
     # @param where_arguments [Hash] Pairs of keys and values for the where clause
     def select_ttl(table, target_attr, where_arguments)
-      statement = select_ttl_statement(table, target_attr, where_arguments)
-      executor.execute(statement).rows.first["ttl(#{target_attr})"]
+      prepared_statement = select_ttl_statement(table, target_attr, where_arguments)
+      executor.execute(prepared_statement, :arguments => where_arguments.values).rows.first["ttl(#{target_attr})"]
     end
 
     # @param table [Symbol] the table name
@@ -66,6 +66,7 @@ module Cassava
       column_names = data.keys
       statement_cql = "INSERT INTO #{table} (#{column_names.join(', ')}) VALUES (#{column_names.map { |x| '?' }.join(',')})"
       statement_cql += " USING TTL #{ttl}" if ttl
+
       executor.prepare(statement_cql)
     end
 
@@ -73,16 +74,9 @@ module Cassava
     # @param target_attr [Symbol] The attribute to select the TTL for
     # @param where_arguments [Hash] Pairs of keys and values for the where clause
     def select_ttl_statement(table, target_attr, where_arguments)
-      statement = "SELECT ttl(#{target_attr}) FROM #{table} WHERE "
-      where_clause = where_arguments.map do |(key, val)|
-        if val.is_a? Integer
-          "#{key} = #{val}"
-        else
-          "#{key} = '#{val}'"
-        end
-      end
-
-      statement + where_clause.join(" AND ")
+      statement_cql = "SELECT ttl(#{target_attr}) FROM #{table} WHERE "
+      statement_cql += where_arguments.keys.map { |x| "#{x} = ? " }.join(" AND ")
+      executor.prepare(statement_cql)
     end
   end
 
@@ -142,6 +136,7 @@ module Cassava
     # @return [StatementBuilder]
     def where(*args)
       clause = clauses[:where] || WhereClause.new([], [])
+
       add_clause(clause.where(*args), :where)
     end
 

--- a/lib/cassava/client.rb
+++ b/lib/cassava/client.rb
@@ -14,10 +14,11 @@ module Cassava
     def insert_async(table, data)
       ttl = data.delete(:ttl)
       consistency = data.delete(:consistency)
+      statement = insert_statement(table, data, ttl)
       if consistency.nil?
-        executor.execute_async(insert_statement(table, data, ttl), :arguments => data.values)
+        executor.execute_async(statement, :arguments => data.values)
       else
-        executor.execute_async(insert_statement(table, data, ttl), { :arguments => data.values, :consistency => consistency })
+        executor.execute_async(statement, { :arguments => data.values, :consistency => consistency })
       end
     end
 

--- a/lib/cassava/version.rb
+++ b/lib/cassava/version.rb
@@ -1,3 +1,3 @@
 module Cassava
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/test/cassava/client_test.rb
+++ b/test/cassava/client_test.rb
@@ -142,6 +142,7 @@ module Cassava
 
       should 'allow clauses to be chained in any order' do
         items = @client.select(:test).limit(2).allow_filtering.where('a >= 2').execute
+        binding.pry
         assert_equal [2, 4].to_set, items.map { |x| x['a'] }.to_set
       end
 

--- a/test/cassava/client_test.rb
+++ b/test/cassava/client_test.rb
@@ -178,14 +178,6 @@ module Cassava
         resulting_ttl = @client.select_ttl(:test, :d, {:id => 'i'})
         assert resulting_ttl.nil?
       end
-
-      should 'handle string vs integer arguments properly' do
-        where_args = { :id => 'i', :a => 1, :b => 'b', :c => "'\"item(" }
-        statement = @client.send(:select_ttl_statement, :test, :c, where_args)
-
-        assert_match /a\s=\s1/, statement
-        assert_match /b\s=\s'b'/, statement
-      end
     end
 
     context 'delete' do
@@ -209,8 +201,8 @@ module Cassava
       should 'delete individual columns' do
         @client.delete(:test, [:c, :d]).where(:id => 'i', :a => 2, :b => 'a').execute
         items = @client.select(:test).where(:id => 'i', :a => 2).execute
-        assert_equal nil, items.first['c']
-        assert_equal nil, items.first['d']
+        assert_nil items.first['c']
+        assert_nil items.first['d']
       end
 
       context 'hash arguments' do

--- a/test/cassava/client_test.rb
+++ b/test/cassava/client_test.rb
@@ -142,8 +142,7 @@ module Cassava
 
       should 'allow clauses to be chained in any order' do
         items = @client.select(:test).limit(2).allow_filtering.where('a >= 2').execute
-        binding.pry
-        assert_equal [2, 4].to_set, items.map { |x| x['a'] }.to_set
+        assert_equal [2, 3].to_set, items.map { |x| x['a'] }.to_set
       end
 
       should 'allow select statements to be modified without affecting the original statement' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,8 +13,8 @@ class Minitest::Should::TestCase
 end
 
 def session_for_keyspace(keyspace = 'test_cassava')
-  c = Cassandra.cluster(port: 9242)
-  c.connect(keyspace)
+  @c ||= Cassandra.cluster(port: 9242)
+  @c.connect(keyspace)
 end
 
 def initialize_test_table


### PR DESCRIPTION
`select_ttl` - as we had it - only supported integer and string types keys. These changes extend it to support any key type by using prepared statement.

Also fixed a failing test and couple of  `Cassandra::Errors::NoHostsAvailable` by memoizing the cluster in test setup.