### PR TITLE
support for select write time

### DIFF
--- a/lib/cassava/client.rb
+++ b/lib/cassava/client.rb
@@ -13,8 +13,11 @@ module Cassava
     # @see #insert
     def insert_async(table, data)
       ttl = data.delete(:ttl)
+      timestamp = data.delete(:timestamp)
       consistency = data.delete(:consistency)
-      statement = insert_statement(table, data, ttl)
+
+      statement = insert_statement(table, data, ttl, timestamp)
+
       if consistency.nil?
         executor.execute_async(statement, :arguments => data.values)
       else
@@ -26,8 +29,11 @@ module Cassava
     # @param data [Hash] A hash of column names to data, which will be inserted into the table
     def insert(table, data)
       ttl = data.delete(:ttl)
+      timestamp = data.delete(:timestamp)
       consistency = data.delete(:consistency)
-      statement = insert_statement(table, data, ttl)
+
+      statement = insert_statement(table, data, ttl, timestamp)
+
       if consistency.nil?
         executor.execute(statement, :arguments => data.values)
       else
@@ -78,10 +84,11 @@ module Cassava
 
     private
 
-    def insert_statement(table, data, ttl = nil)
+    def insert_statement(table, data, ttl = nil, timestamp = nil)
       column_names = data.keys
       statement_cql = "INSERT INTO #{table} (#{column_names.join(', ')}) VALUES (#{column_names.map { |x| '?' }.join(',')})"
-      statement_cql += " USING TTL #{ttl}" if ttl
+      statement_cql += " USING TTL #{ttl} " if ttl
+      statement_cql += " USING TIMESTAMP #{timestamp}" if timestamp
 
       executor.prepare(statement_cql)
     end

--- a/lib/cassava/client.rb
+++ b/lib/cassava/client.rb
@@ -87,8 +87,14 @@ module Cassava
     def insert_statement(table, data, ttl = nil, timestamp = nil)
       column_names = data.keys
       statement_cql = "INSERT INTO #{table} (#{column_names.join(', ')}) VALUES (#{column_names.map { |x| '?' }.join(',')})"
-      statement_cql += " USING TTL #{ttl} " if ttl
-      statement_cql += " USING TIMESTAMP #{timestamp}" if timestamp
+      
+      if ttl && timestamp
+        statement_cql += " USING TTL #{ttl} AND TIMESTAMP #{timestamp}" 
+      elsif ttl
+        statement_cql += " USING TTL #{ttl} "
+      elsif timestamp
+        statement_cql += " USING TIMESTAMP #{timestamp}"
+      end
 
       executor.prepare(statement_cql)
     end

--- a/lib/cassava/client.rb
+++ b/lib/cassava/client.rb
@@ -13,10 +13,10 @@ module Cassava
     # @see #insert
     def insert_async(table, data)
       ttl = data.delete(:ttl)
-      timestamp = data.delete(:timestamp)
+      optional_timestamp = data.delete(:optional_timestamp)
       consistency = data.delete(:consistency)
 
-      statement = insert_statement(table, data, ttl, timestamp)
+      statement = insert_statement(table, data, ttl, optional_timestamp)
 
       if consistency.nil?
         executor.execute_async(statement, :arguments => data.values)
@@ -29,10 +29,10 @@ module Cassava
     # @param data [Hash] A hash of column names to data, which will be inserted into the table
     def insert(table, data)
       ttl = data.delete(:ttl)
-      timestamp = data.delete(:timestamp)
+      optional_timestamp = data.delete(:optional_timestamp)
       consistency = data.delete(:consistency)
 
-      statement = insert_statement(table, data, ttl, timestamp)
+      statement = insert_statement(table, data, ttl, optional_timestamp)
 
       if consistency.nil?
         executor.execute(statement, :arguments => data.values)
@@ -84,16 +84,16 @@ module Cassava
 
     private
 
-    def insert_statement(table, data, ttl = nil, timestamp = nil)
+    def insert_statement(table, data, ttl = nil, optional_timestamp = nil)
       column_names = data.keys
       statement_cql = "INSERT INTO #{table} (#{column_names.join(', ')}) VALUES (#{column_names.map { |x| '?' }.join(',')})"
       
-      if ttl && timestamp
-        statement_cql += " USING TTL #{ttl} AND TIMESTAMP #{timestamp}" 
+      if ttl && optional_timestamp
+        statement_cql += " USING TTL #{ttl} AND TIMESTAMP #{optional_timestamp}" 
       elsif ttl
         statement_cql += " USING TTL #{ttl} "
-      elsif timestamp
-        statement_cql += " USING TIMESTAMP #{timestamp}"
+      elsif optional_timestamp
+        statement_cql += " USING TIMESTAMP #{optional_timestamp}"
       end
 
       executor.prepare(statement_cql)

--- a/lib/cassava/client.rb
+++ b/lib/cassava/client.rb
@@ -50,6 +50,11 @@ module Cassava
       executor.execute(prepared_statement, :arguments => where_arguments.values).rows.first["ttl(#{target_attr})"]
     end
 
+    def select_writetime(table, target_attr, where_arguments)
+      prepared_statement = select_writetime_statement(table, target_attr, where_arguments)
+      executor.execute(prepared_statement, :arguments => where_arguments.values).rows.first["writetime(#{target_attr})"]
+    end
+
     # @param table [Symbol] the table name
     # @param columns [Array<String] A list of columns that will be deleted. If nil, all columns will be deleted.
     # @return [StatementBuilder] A statement builder representing the partially completed statement.
@@ -86,6 +91,15 @@ module Cassava
     # @param where_arguments [Hash] Pairs of keys and values for the where clause
     def select_ttl_statement(table, target_attr, where_arguments)
       statement_cql = "SELECT ttl(#{target_attr}) FROM #{table} WHERE "
+      statement_cql += where_arguments.keys.map { |x| "#{x} = ? " }.join(" AND ")
+      executor.prepare(statement_cql)
+    end
+
+    # @param table [Symbol] the table name
+    # @param target_attr [Symbol] The attribute to select the write time(timestamp) for
+    # @param where_arguments [Hash] Pairs of keys and values for the where clause
+    def select_writetime_statement(table, target_attr, where_arguments)
+      statement_cql = "SELECT WRITETIME(#{target_attr}) FROM #{table} WHERE "
       statement_cql += where_arguments.keys.map { |x| "#{x} = ? " }.join(" AND ")
       executor.prepare(statement_cql)
     end

--- a/lib/cassava/version.rb
+++ b/lib/cassava/version.rb
@@ -1,3 +1,3 @@
 module Cassava
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/test/cassava/client_test.rb
+++ b/test/cassava/client_test.rb
@@ -47,8 +47,18 @@ module Cassava
         item = { :id => 'i', :a => 1, :b => 'b', :c => "'\"item(", :d => 1, :ttl => ttl }
         @client.insert(:test, item)
 
-        assert @client.send(:insert_statement, :test, item, ttl).cql =~ /\sUSING\sTTL\s#{ttl}$/
+        assert @client.send(:insert_statement, :test, item, ttl).cql =~ /\sUSING\sTTL\s#{ttl}/
         assert_equal string_keys(item), @client.select(:test).execute.first
+      end
+
+      should 'allow the insertion with a timestamp' do
+        timestamp = Time.now.to_i
+        item = { :id => 'i', :a => 1, :b => 'b', :c => "'\"item(", :d => 1, :timestamp => timestamp }
+        @client.insert(:test, item)
+
+        assert @client.send(:insert_statement, :test, item, nil, timestamp).cql =~ /\sUSING\sTIMESTAMP\s#{timestamp}/
+        saved_timestamp = @client.select_writetime(:test, :d, { :id => 'i' })
+        assert_equal timestamp, saved_timestamp
       end
     end
 

--- a/test/cassava/client_test.rb
+++ b/test/cassava/client_test.rb
@@ -52,7 +52,7 @@ module Cassava
       end
 
       should 'allow the insertion with a timestamp' do
-        timestamp = Time.now.to_i
+        timestamp = Time.now.to_i * 1000000 + Time.now.usec
         item = { :id => 'i', :a => 1, :b => 'b', :c => "'\"item(", :d => 1, :optional_timestamp => timestamp }
         @client.insert(:test, item)
 
@@ -63,7 +63,7 @@ module Cassava
 
       should 'allow the insertion of a ttl and a timestamp' do
         ttl = 12345
-        timestamp = Time.now.to_i
+        timestamp = Time.now.to_i * 1000000 + Time.now.usec
         item = { :id => 'i', :a => 1, :b => 'b', :c => "'\"item(", :d => 1, :ttl => ttl, :optional_timestamp => timestamp }
         @client.insert(:test, item)
 

--- a/test/cassava/client_test.rb
+++ b/test/cassava/client_test.rb
@@ -60,6 +60,18 @@ module Cassava
         saved_timestamp = @client.select_writetime(:test, :d, { :id => 'i' })
         assert_equal timestamp, saved_timestamp
       end
+
+      should 'allow the insertion of a ttl and a timestamp' do
+        ttl = 12345
+        timestamp = Time.now.to_i
+        item = { :id => 'i', :a => 1, :b => 'b', :c => "'\"item(", :d => 1, :ttl => ttl, :timestamp => timestamp }
+        @client.insert(:test, item)
+
+        assert @client.send(:insert_statement, :test, item, ttl, timestamp).cql =~ /\sUSING\sTTL\s#{ttl}\sAND\sTIMESTAMP\s#{timestamp}/
+        assert_equal string_keys(item), @client.select(:test).execute.first
+        saved_timestamp = @client.select_writetime(:test, :d, { :id => 'i' })
+        assert_equal timestamp, saved_timestamp
+      end
     end
 
     context 'select' do

--- a/test/cassava/client_test.rb
+++ b/test/cassava/client_test.rb
@@ -180,6 +180,21 @@ module Cassava
       end
     end
 
+    context 'select_writetime' do
+      should 'build the correct writetime select statement' do
+        statement = @client.send(:select_writetime_statement, :test, :d, { :id => 'i' })
+        assert_match /SELECT WRITETIME/, statement.cql
+      end
+
+      should 'correctly fetch the timestamp of a given column' do
+        item = { :id => 'i', :a => 1, :b => 'b', :c => "item", :d => 1 }
+        @client.insert(:test, item)
+
+        timestamp = @client.select_writetime(:test, :d, { :id => 'i' })
+        assert timestamp
+      end
+    end
+
     context 'delete' do
       setup do
         @client.insert(:test, :id => 'i', :a => 2, :b => 'a', :c => '1', :d => 1)


### PR DESCRIPTION
These changes allow us to use or request timestamps  (i.e the time a column was written) for reading, writing, or deleting.These timestamps are column metadata, and not stored as a separate column. This change is needed for the ThriftToCqlClient which reads and writes thrifty data using cql. 